### PR TITLE
Check wordReviewRecords table structure consistency

### DIFF
--- a/src/server/controllers/syncController.ts
+++ b/src/server/controllers/syncController.ts
@@ -269,6 +269,7 @@ export const syncData = async (req: Request, res: Response) => {
         // 需要进行字段映射和类型转换
         const {
           uuid,
+          id: clientLocalId,
           word,
           // 客户端算法字段
           intervalSequence,
@@ -340,6 +341,9 @@ export const syncData = async (req: Request, res: Response) => {
             serverRecord.clientModifiedAt =
               safeParseDate(clientLastModified) || new Date();
             serverRecord.isDeleted = clientIsDeleted || false;
+            if (typeof clientLocalId === "number") {
+              (serverRecord as any).clientLocalId = clientLocalId;
+            }
 
             await serverRecord.save();
           } else {
@@ -364,24 +368,29 @@ export const syncData = async (req: Request, res: Response) => {
               last_modified: clientLastModified || Date.now(),
               clientModifiedAt: safeParseDate(clientLastModified) || new Date(),
               isDeleted: clientIsDeleted || false,
+              clientLocalId:
+                typeof clientLocalId === "number" ? clientLocalId : undefined,
             });
 
             await serverRecord.save();
           }
         } else if (action === "delete") {
           const serverRecord = await WordReviewRecordModel.findOne(query);
-          if (serverRecord) {
-            if ("isDeleted" in WordReviewRecordModel.schema.paths) {
-              serverRecord.isDeleted = true;
-              serverRecord.last_modified =
-                clientRecordData.last_modified || Date.now();
-              serverRecord.clientModifiedAt =
-                safeParseDate(clientRecordData.last_modified) || new Date();
-              await serverRecord.save();
-            } else {
-              await WordReviewRecordModel.findOneAndDelete(query);
+                      if (serverRecord) {
+              if ("isDeleted" in WordReviewRecordModel.schema.paths) {
+                serverRecord.isDeleted = true;
+                serverRecord.last_modified =
+                  clientRecordData.last_modified || Date.now();
+                serverRecord.clientModifiedAt =
+                  safeParseDate(clientRecordData.last_modified) || new Date();
+                if (typeof clientRecordData.id === "number") {
+                  (serverRecord as any).clientLocalId = clientRecordData.id;
+                }
+                await serverRecord.save();
+              } else {
+                await WordReviewRecordModel.findOneAndDelete(query);
+              }
             }
-          }
         }
       } else if (table === "familiarWords") {
         // 特殊处理 FamiliarWord 表，使用 (userId, dict, word) 作为唯一标识

--- a/src/server/models/WordReviewRecord.ts
+++ b/src/server/models/WordReviewRecord.ts
@@ -38,6 +38,8 @@ export interface IWordReviewRecord extends Document {
   last_modified: number; // 客户端记录的最后修改时间戳
   clientModifiedAt: Date; // 客户端记录的最后修改时间
   isDeleted: boolean; // 是否已删除
+  // 客户端本地标识
+  clientLocalId?: number; // 本地 Dexie 自增ID（可选）
 
   // Mongoose Timestamps
   createdAt: Date;
@@ -163,6 +165,10 @@ const WordReviewRecordSchema: Schema<IWordReviewRecord> = new Schema(
       type: Boolean,
       default: false,
       // 移除 index: true，isDeleted 索引不是必需的
+    },
+    clientLocalId: {
+      type: Number,
+      required: false,
     },
   },
   { timestamps: true }

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -251,6 +251,7 @@ interface IWordReviewRecord extends IBaseRecord {
   sourceDicts: string[];
   preferredDict: string;
   firstSeenAt: number;
+  clientLocalId?: number; // 云端回传的本地 Dexie 自增ID
 }
 
 interface IReviewHistory extends IBaseRecord {
@@ -642,6 +643,15 @@ const applyServerChanges = async (serverChanges: any[]) => {
         for (const data of allUpsertData) {
           const localRecord = localRecordMap.get(data.uuid);
 
+          // 如果服务器带回 clientLocalId，尝试与本地记录关联
+          let preferredLocalId: number | undefined = undefined;
+          if (!localRecord && typeof data.clientLocalId === "number") {
+            const byId = await dbTable.get(data.clientLocalId);
+            if (byId && byId.uuid === data.uuid) {
+              preferredLocalId = byId.id;
+            }
+          }
+
           if (localRecord && localRecord.id) {
             // 更新操作：合并服务器数据和本地数据
             const mergedData = {
@@ -652,8 +662,17 @@ const applyServerChanges = async (serverChanges: any[]) => {
               last_modified: Date.now(),
             };
             upserts.push(mergedData);
+          } else if (preferredLocalId !== undefined) {
+            // 使用服务器提供的 clientLocalId 来维持本地 id
+            const mergedData = {
+              ...data,
+              id: preferredLocalId,
+              sync_status: "synced" as SyncStatus,
+              last_modified: Date.now(),
+            };
+            upserts.push(mergedData);
           } else {
-            // 创建操作：直接使用服务器数据
+            // 创建操作：直接使用服务器数据（让 Dexie 分配新 id）
             const newData = {
               ...data,
               sync_status: "synced" as SyncStatus,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,11 +2606,6 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz"
   integrity sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==
 
-"@types/pako@^2.0.0":
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz"
-  integrity sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==
-
 "@types/parse-json@^4.0.0":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz"
@@ -3966,11 +3961,6 @@ detective@^5.2.0:
     acorn-node "^1.8.2"
     defined "^1.0.0"
     minimist "^1.2.6"
-
-dexie-export-import@^4.0.7:
-  version "4.1.4"
-  resolved "https://registry.npmjs.org/dexie-export-import/-/dexie-export-import-4.1.4.tgz"
-  integrity sha512-3bw171qUuOTWSYLXI7C/0M6p1X65Rho3tu1IvD9By8jn0+3t3dLSkDlZ1BC6MbABl3kRlhtGigzC+SF+qcS5Og==
 
 dexie-react-hooks@^1.1.3:
   version "1.1.7"
@@ -6537,11 +6527,6 @@ package-manager-detector@^0.2.8:
   integrity sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==
   dependencies:
     quansync "^0.2.7"
-
-pako@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz"
-  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 pako@~1.0.2:
   version "1.0.11"


### PR DESCRIPTION
Add `clientLocalId` to `WordReviewRecord` to sync local Dexie IDs to the cloud.

This change enables traceability of local records on the server and allows the client to preserve local IDs when applying server changes, without affecting existing unique constraints.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8c955ea-2895-4c55-963d-5c7b2ce86c45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8c955ea-2895-4c55-963d-5c7b2ce86c45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

